### PR TITLE
Contain stop list within modal

### DIFF
--- a/src/components/RoutesList.tsx
+++ b/src/components/RoutesList.tsx
@@ -244,8 +244,8 @@ const RoutesList: React.FC<RoutesListProps> = ({ onRouteSelect, selectedRoute, o
                             </Select>
                           </div>
 
-                          <ScrollArea className="h-[600px] pr-4 overflow-y-auto">
-                            <div className="space-y-1 max-h-[600px]">
+                          <ScrollArea className="h-[400px] pr-4 overflow-y-auto">
+                            <div className="space-y-1">
                               {/* Header row */}
                               <div className="grid grid-cols-2 gap-4 p-3 bg-muted/50 rounded-lg font-medium text-sm">
                                 <div>Stop Name</div>


### PR DESCRIPTION
Adjust ScrollArea height in stop list to prevent overflow in modal dialog.

---
<a href="https://cursor.com/background-agent?bcId=bc-af55be93-cebf-48eb-b661-63cb72ac2215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af55be93-cebf-48eb-b661-63cb72ac2215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>