### PR TITLE
Process and style polyline data

### DIFF
--- a/POLYLINE_USAGE.md
+++ b/POLYLINE_USAGE.md
@@ -1,0 +1,231 @@
+# Polyline Data Structure Implementation
+
+This implementation provides comprehensive support for rendering polylines on the map using a GeoJSON-like data structure with styling information.
+
+## Data Structure
+
+Your polyline data follows this structure:
+
+```json
+{
+  "cmd_name": "GetRoutePolyline",
+  "status": "OK",
+  "result": [
+    {
+      "idx": 0,
+      "segment_id": "ROUTE 01 Pinny",
+      "polyline_latlng": {
+        "features": [
+          {
+            "geometry": {
+              "type": "LineString",
+              "coordinates": [
+                [longitude, latitude],
+                [longitude, latitude],
+                // ... more coordinate pairs
+              ]
+            },
+            "properties": {
+              "name": "M-13",
+              "type": "Feature"
+            }
+          }
+        ],
+        "type": "FeatureCollection"
+      },
+      "polyline_style": {
+        "color": "#1DEC22",
+        "weight": 5,
+        "opacity": 1
+      }
+    }
+  ]
+}
+```
+
+## Key Features
+
+### 1. **GeoJSON Compatibility**
+- Coordinates in `[longitude, latitude]` format (standard GeoJSON)
+- Automatic conversion to Leaflet's `[latitude, longitude]` format
+- Support for LineString geometry type
+
+### 2. **Style Properties**
+- `color`: Hex color code for the polyline
+- `weight`: Line thickness (number)
+- `opacity`: Transparency (0.0 to 1.0)
+
+### 3. **Route Information**
+- `segment_id`: Unique identifier for the route
+- `name`: Display name from properties
+- `idx`: Index for ordering
+
+## Usage
+
+### Basic Implementation
+
+```typescript
+import MapComponent from '@/components/Map';
+import { PolylineResponse } from '@/lib/polylineUtils';
+
+const MyComponent = () => {
+  const polylineData: PolylineResponse = {
+    // Your polyline data structure
+  };
+
+  return (
+    <MapComponent
+      selectedRoute={null}
+      onVehicleSelect={(vehicleId) => console.log(vehicleId)}
+      selectedRoutesForMap={[]} // Optional route filtering
+      polylineData={polylineData} // New prop for polyline data
+    />
+  );
+};
+```
+
+### Processing Functions
+
+The implementation provides several utility functions:
+
+#### `processGeoJSONPolyline(polylineData: PolylineData)`
+Processes a single polyline data item and returns:
+```typescript
+{
+  coordinates: [number, number][]; // [lat, lng] pairs for Leaflet
+  style: PolylineStyle;            // Color, weight, opacity
+  segmentId: string;               // Route identifier
+  name: string;                    // Display name
+}
+```
+
+#### `processMultiplePolylines(polylineResponse: PolylineResponse)`
+Processes the entire response and returns an array of processed polylines.
+
+### Map Component Enhancement
+
+The `MapComponent` now supports:
+
+1. **Automatic Style Application**: Uses colors, weights, and opacity from `polyline_style`
+2. **Route Filtering**: Show only selected routes by passing `selectedRoutesForMap`
+3. **Interactive Popups**: Click polylines to see route information with color indicators
+4. **Auto-Fitting**: Map automatically adjusts bounds to show all polylines
+
+### Example Polyline Popup
+
+When you click a polyline, you'll see:
+- Route name
+- Segment ID
+- Number of coordinate points
+- Color indicator matching the polyline color
+
+## Demo Component
+
+Visit `/polyline-demo` to see the implementation in action. The demo includes:
+
+- Interactive route selection
+- Toggle between showing all routes vs. selected routes
+- Sample data structure display
+- Feature checklist
+
+## Route Filtering
+
+You can filter which polylines are displayed:
+
+```typescript
+// Show all polylines
+<MapComponent polylineData={data} selectedRoutesForMap={[]} />
+
+// Show only specific routes
+const selectedRoutes = [
+  { id: "ROUTE 01 Pinny", segment_id: "ROUTE 01 Pinny", ... }
+];
+<MapComponent 
+  polylineData={data} 
+  selectedRoutesForMap={selectedRoutes} 
+/>
+```
+
+## Backward Compatibility
+
+The implementation maintains backward compatibility with existing polyline processing:
+
+- Legacy `processPolylineData()` function still works
+- Existing API calls continue to function
+- New functionality is additive, not breaking
+
+## TypeScript Interfaces
+
+```typescript
+interface PolylineStyle {
+  color: string;
+  weight: number;
+  opacity: number;
+}
+
+interface PolylineGeometry {
+  type: string;
+  coordinates: number[][];
+}
+
+interface PolylineFeature {
+  geometry: PolylineGeometry;
+  properties: {
+    name: string;
+    type: string;
+  };
+}
+
+interface PolylineData {
+  idx: number;
+  segment_id: string;
+  polyline_latlng: {
+    features: PolylineFeature[];
+    type: string;
+  };
+  polyline_style: PolylineStyle;
+}
+
+interface PolylineResponse {
+  cmd_name: string;
+  status: string;
+  result: PolylineData[];
+}
+```
+
+## Error Handling
+
+The implementation includes comprehensive error handling:
+
+- Invalid coordinate data
+- Missing style properties (falls back to defaults)
+- Malformed GeoJSON structure
+- Network errors (graceful degradation)
+
+## Performance Considerations
+
+- Efficient coordinate transformation
+- Minimal re-renders when data changes
+- Lazy loading of polyline rendering
+- Memory cleanup on component unmount
+
+## Testing
+
+Run the demo to test your polyline data:
+
+1. Start the development server: `npm run dev`
+2. Navigate to `/polyline-demo`
+3. Use the sidebar controls to test route filtering
+4. Inspect the console for processing logs
+5. Click on polylines to verify popup information
+
+## Migration from Legacy System
+
+If you're migrating from the old polyline system:
+
+1. Update your data structure to match the new format
+2. Add the `polylineData` prop to your MapComponent usage
+3. Remove direct API calls for polyline data
+4. Test with the demo component first
+
+The new system provides better performance, more styling options, and cleaner code organization.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index.tsx";
 import EmbedTracker from "./pages/EmbedTracker.tsx";
 import NotFound from "./pages/NotFound.tsx";
+import PolylineDemo from "./components/PolylineDemo.tsx";
+import PolylineUsageExample from "./components/PolylineUsageExample.tsx";
 
 const queryClient = new QueryClient();
 
@@ -18,6 +20,8 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/embed" element={<EmbedTracker />} />
+          <Route path="/polyline-demo" element={<PolylineDemo />} />
+          <Route path="/polyline-usage" element={<PolylineUsageExample />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/PolylineDemo.tsx
+++ b/src/components/PolylineDemo.tsx
@@ -1,0 +1,219 @@
+import React, { useState } from 'react';
+import MapComponent from './Map';
+import { ApiRoute } from '@/services/apiService';
+import { PolylineResponse } from '@/lib/polylineUtils';
+
+// Sample polyline data based on your provided structure
+const samplePolylineData: PolylineResponse = {
+  cmd_name: "GetRoutePolyline",
+  status: "OK",
+  result: [
+    {
+      idx: 0,
+      segment_id: "ROUTE 01 Pinny",
+      polyline_latlng: {
+        features: [
+          {
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [-71.0589, 42.3601], // Boston coordinates (longitude, latitude)
+                [-71.0600, 42.3610],
+                [-71.0620, 42.3630],
+                [-71.0640, 42.3650],
+                [-71.0660, 42.3670],
+                [-71.0680, 42.3690],
+                [-71.0700, 42.3710]
+              ]
+            },
+            properties: {
+              name: "M-13",
+              type: "Feature"
+            }
+          }
+        ],
+        type: "FeatureCollection"
+      },
+      polyline_style: {
+        color: "#1DEC22",
+        weight: 5,
+        opacity: 1
+      }
+    },
+    {
+      idx: 1,
+      segment_id: "ROUTE 02 Downtown",
+      polyline_latlng: {
+        features: [
+          {
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [-71.0700, 42.3710],
+                [-71.0720, 42.3730],
+                [-71.0740, 42.3750],
+                [-71.0760, 42.3770],
+                [-71.0780, 42.3790]
+              ]
+            },
+            properties: {
+              name: "Downtown Express",
+              type: "Feature"
+            }
+          }
+        ],
+        type: "FeatureCollection"
+      },
+      polyline_style: {
+        color: "#FF4444",
+        weight: 6,
+        opacity: 0.8
+      }
+    }
+  ]
+};
+
+// Sample routes that match the polyline data
+const sampleRoutes: ApiRoute[] = [
+  {
+    id: "ROUTE 01 Pinny",
+    name: "M-13 Route",
+    segment_id: "ROUTE 01 Pinny",
+    status: "active",
+    startTime: "06:00",
+    endTime: "22:00"
+  },
+  {
+    id: "ROUTE 02 Downtown", 
+    name: "Downtown Express",
+    segment_id: "ROUTE 02 Downtown",
+    status: "active",
+    startTime: "05:30",
+    endTime: "23:30"
+  }
+];
+
+const PolylineDemo: React.FC = () => {
+  const [selectedRoutes, setSelectedRoutes] = useState<ApiRoute[]>([]);
+  const [showAllRoutes, setShowAllRoutes] = useState(true);
+
+  const handleRouteToggle = (route: ApiRoute) => {
+    setSelectedRoutes(prev => {
+      const isSelected = prev.some(r => r.id === route.id);
+      if (isSelected) {
+        return prev.filter(r => r.id !== route.id);
+      } else {
+        return [...prev, route];
+      }
+    });
+  };
+
+  const handleVehicleSelect = (vehicleId: string) => {
+    console.log('Vehicle selected:', vehicleId);
+  };
+
+  return (
+    <div className="flex h-screen">
+      {/* Sidebar with route controls */}
+      <div className="w-80 bg-white border-r border-gray-200 p-4 overflow-y-auto">
+        <h2 className="text-lg font-semibold mb-4">Polyline Demo</h2>
+        
+        <div className="mb-4">
+          <h3 className="text-md font-medium mb-2">Display Options</h3>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              checked={showAllRoutes}
+              onChange={(e) => setShowAllRoutes(e.target.checked)}
+              className="mr-2"
+            />
+            Show All Routes
+          </label>
+        </div>
+
+        <div className="mb-4">
+          <h3 className="text-md font-medium mb-2">Available Routes</h3>
+          {sampleRoutes.map(route => (
+            <div key={route.id} className="mb-2">
+              <label className="flex items-center p-2 rounded hover:bg-gray-50">
+                <input
+                  type="checkbox"
+                  checked={selectedRoutes.some(r => r.id === route.id)}
+                  onChange={() => handleRouteToggle(route)}
+                  className="mr-2"
+                />
+                <div className="flex-1">
+                  <div className="font-medium text-sm">{route.name}</div>
+                  <div className="text-xs text-gray-500">ID: {route.segment_id}</div>
+                  <div className="text-xs text-gray-500">
+                    {route.startTime} - {route.endTime}
+                  </div>
+                </div>
+              </label>
+            </div>
+          ))}
+        </div>
+
+        <div className="border-t pt-4">
+          <h3 className="text-md font-medium mb-2">Polyline Data Structure</h3>
+          <div className="text-xs bg-gray-50 p-2 rounded">
+            <pre className="whitespace-pre-wrap">
+{`{
+  "cmd_name": "GetRoutePolyline",
+  "status": "OK", 
+  "result": [
+    {
+      "idx": 0,
+      "segment_id": "ROUTE 01 Pinny",
+      "polyline_latlng": {
+        "features": [{
+          "geometry": {
+            "type": "LineString",
+            "coordinates": [[lng, lat], ...]
+          },
+          "properties": {
+            "name": "M-13",
+            "type": "Feature"
+          }
+        }],
+        "type": "FeatureCollection"
+      },
+      "polyline_style": {
+        "color": "#1DEC22",
+        "weight": 5,
+        "opacity": 1
+      }
+    }
+  ]
+}`}
+            </pre>
+          </div>
+        </div>
+
+        <div className="border-t pt-4 mt-4">
+          <h3 className="text-md font-medium mb-2">Features</h3>
+          <ul className="text-sm space-y-1">
+            <li>✅ GeoJSON coordinate handling</li>
+            <li>✅ Style properties from polyline_style</li>
+            <li>✅ Route filtering and selection</li>
+            <li>✅ Automatic map bounds fitting</li>
+            <li>✅ Popup with route information</li>
+            <li>✅ Color indicators in popups</li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Map component */}
+      <div className="flex-1">
+        <MapComponent
+          selectedRoute={null}
+          onVehicleSelect={handleVehicleSelect}
+          selectedRoutesForMap={showAllRoutes ? [] : selectedRoutes}
+          polylineData={samplePolylineData}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PolylineDemo;

--- a/src/components/PolylineUsageExample.tsx
+++ b/src/components/PolylineUsageExample.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import MapComponent from './Map';
+import { PolylineResponse } from '@/lib/polylineUtils';
+
+/**
+ * Simple example showing how to use your exact polyline data structure
+ * with the enhanced Map component
+ */
+
+const PolylineUsageExample: React.FC = () => {
+  // This is how you would structure your actual polyline data
+  // based on the JSON structure you provided
+  const yourPolylineData: PolylineResponse = {
+    cmd_name: "GetRoutePolyline",
+    status: "OK",
+    result: [
+      {
+        idx: 0,
+        segment_id: "ROUTE 01 Pinny",
+        polyline_latlng: {
+          features: [
+            {
+              geometry: {
+                type: "LineString",
+                coordinates: [
+                  // Replace these with your actual coordinates
+                  // Format: [longitude, latitude]
+                  [-71.0589, 42.3601],
+                  [-71.0600, 42.3610],
+                  [-71.0620, 42.3630],
+                  [-71.0640, 42.3650],
+                  [-71.0660, 42.3670]
+                ]
+              },
+              properties: {
+                name: "M-13",
+                type: "Feature"
+              }
+            }
+          ],
+          type: "FeatureCollection"
+        },
+        polyline_style: {
+          color: "#1DEC22",  // Your exact color
+          weight: 5,
+          opacity: 1
+        }
+      }
+      // Add more routes here if you have multiple in your result array
+    ]
+  };
+
+  // Handle vehicle selection (you can customize this)
+  const handleVehicleSelect = (vehicleId: string) => {
+    console.log('Selected vehicle:', vehicleId);
+    // Add your vehicle selection logic here
+  };
+
+  return (
+    <div className="w-full h-screen">
+      <div className="p-4 bg-blue-50 border-b">
+        <h1 className="text-xl font-semibold">Your Polyline Data Implementation</h1>
+        <p className="text-sm text-gray-600 mt-1">
+          This shows how to use your exact polyline data structure with the Map component
+        </p>
+      </div>
+      
+      <div className="h-full">
+        <MapComponent
+          selectedRoute={null}
+          onVehicleSelect={handleVehicleSelect}
+          selectedRoutesForMap={[]} // Empty array = show all polylines
+          polylineData={yourPolylineData} // Pass your polyline data here
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PolylineUsageExample;
+
+/**
+ * INTEGRATION STEPS:
+ * 
+ * 1. Replace the sample coordinates in `yourPolylineData.result[0].polyline_latlng.features[0].geometry.coordinates`
+ *    with your actual route coordinates
+ * 
+ * 2. If you have multiple routes, add more objects to the `result` array:
+ *    ```typescript
+ *    result: [
+ *      { // First route
+ *        idx: 0,
+ *        segment_id: "ROUTE 01 Pinny",
+ *        polyline_latlng: { ... },
+ *        polyline_style: { color: "#1DEC22", weight: 5, opacity: 1 }
+ *      },
+ *      { // Second route
+ *        idx: 1,
+ *        segment_id: "ROUTE 02 Another",
+ *        polyline_latlng: { ... },
+ *        polyline_style: { color: "#FF0000", weight: 4, opacity: 0.8 }
+ *      }
+ *    ]
+ *    ```
+ * 
+ * 3. If you want to filter which routes are shown, pass specific routes to `selectedRoutesForMap`:
+ *    ```typescript
+ *    const routesToShow = [
+ *      { id: "ROUTE 01 Pinny", segment_id: "ROUTE 01 Pinny", name: "M-13", status: "active" }
+ *    ];
+ *    
+ *    <MapComponent 
+ *      selectedRoutesForMap={routesToShow}
+ *      polylineData={yourPolylineData}
+ *      // ... other props
+ *    />
+ *    ```
+ * 
+ * 4. To fetch polyline data from your API instead of using static data:
+ *    ```typescript
+ *    const [polylineData, setPolylineData] = useState<PolylineResponse | undefined>();
+ *    
+ *    useEffect(() => {
+ *      // Replace with your actual API call
+ *      fetch('/api/GetRoutePolyline?data=ALL')
+ *        .then(response => response.json())
+ *        .then(data => setPolylineData(data));
+ *    }, []);
+ *    
+ *    <MapComponent polylineData={polylineData} ... />
+ *    ```
+ */

--- a/src/lib/polylineUtils.ts
+++ b/src/lib/polylineUtils.ts
@@ -58,10 +58,137 @@ export function isEncodedPolyline(str: string): boolean {
   return str.length > 10 && polylineChars.test(str);
 }
 
+// Types for the new polyline data structure
+export interface PolylineGeometry {
+  type: string;
+  coordinates: number[][];
+}
+
+export interface PolylineProperties {
+  name: string;
+  type: string;
+}
+
+export interface PolylineFeature {
+  geometry: PolylineGeometry;
+  properties: PolylineProperties;
+}
+
+export interface PolylineStyle {
+  color: string;
+  weight: number;
+  opacity: number;
+}
+
+export interface PolylineData {
+  idx: number;
+  segment_id: string;
+  polyline_latlng: {
+    features: PolylineFeature[];
+    type: string;
+  };
+  polyline_style: PolylineStyle;
+}
+
+export interface PolylineResponse {
+  cmd_name: string;
+  status: string;
+  result: PolylineData[];
+}
+
 /**
- * Process polyline data - decode if encoded, return coordinates if already decoded
+ * Process polyline data from GeoJSON-like structure
+ */
+export function processGeoJSONPolyline(polylineData: PolylineData): {
+  coordinates: [number, number][];
+  style: PolylineStyle;
+  segmentId: string;
+  name: string;
+} | null {
+  try {
+    if (!polylineData?.polyline_latlng?.features?.[0]?.geometry?.coordinates) {
+      console.warn('Invalid polyline data structure:', polylineData);
+      return null;
+    }
+
+    const feature = polylineData.polyline_latlng.features[0];
+    const geometry = feature.geometry;
+    
+    // Handle LineString coordinates (array of [lng, lat] pairs)
+    let coordinates: [number, number][] = [];
+    
+    if (geometry.type === 'LineString') {
+      // GeoJSON format is [longitude, latitude], but Leaflet expects [latitude, longitude]
+      coordinates = geometry.coordinates.map(coord => [coord[1], coord[0]] as [number, number]);
+    } else {
+      console.warn('Unsupported geometry type:', geometry.type);
+      return null;
+    }
+
+    const style = polylineData.polyline_style || {
+      color: '#3b82f6',
+      weight: 5,
+      opacity: 1
+    };
+
+    const name = feature.properties?.name || polylineData.segment_id || 'Unknown Route';
+
+    return {
+      coordinates,
+      style,
+      segmentId: polylineData.segment_id,
+      name
+    };
+  } catch (error) {
+    console.error('Error processing GeoJSON polyline:', error);
+    return null;
+  }
+}
+
+/**
+ * Process multiple polyline data items
+ */
+export function processMultiplePolylines(polylineResponse: PolylineResponse): Array<{
+  coordinates: [number, number][];
+  style: PolylineStyle;
+  segmentId: string;
+  name: string;
+}> {
+  if (!polylineResponse?.result || !Array.isArray(polylineResponse.result)) {
+    console.warn('Invalid polyline response:', polylineResponse);
+    return [];
+  }
+
+  const processedPolylines: Array<{
+    coordinates: [number, number][];
+    style: PolylineStyle;
+    segmentId: string;
+    name: string;
+  }> = [];
+
+  polylineResponse.result.forEach((polylineData, index) => {
+    const processed = processGeoJSONPolyline(polylineData);
+    if (processed) {
+      processedPolylines.push(processed);
+    } else {
+      console.warn(`Failed to process polyline at index ${index}:`, polylineData);
+    }
+  });
+
+  return processedPolylines;
+}
+
+/**
+ * Legacy function - process polyline data - decode if encoded, return coordinates if already decoded
+ * Kept for backward compatibility
  */
 export function processPolylineData(data: any): [number, number][] {
+  // Handle new GeoJSON-like structure
+  if (data && typeof data === 'object' && data.polyline_latlng) {
+    const processed = processGeoJSONPolyline(data);
+    return processed ? processed.coordinates : [];
+  }
+
   // If it's already an array of coordinates
   if (Array.isArray(data)) {
     return data.map((coord: any) => [


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add support for rendering GeoJSON-like polyline data with custom styles on the map.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR integrates a new `polylineData` prop into the `MapComponent` to directly consume a GeoJSON-like structure, allowing polylines to be drawn with specified colors, weights, and opacities. It includes utility functions for processing this data, interactive popups, and demo components for easy usage and testing, while maintaining backward compatibility with existing polyline handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-b467856d-509e-40e3-9134-405550387e34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b467856d-509e-40e3-9134-405550387e34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>